### PR TITLE
 scalatest to 3.1.0-RC3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,8 +40,8 @@ lazy val contributors = Seq(
 val betterMonadicForV = "0.3.1"
 val disciplineV = "1.0.0"
 val kindProjectorV = "0.10.3"
-val scalatestV = "3.2.0-M1"
-val scalatestplusScalacheckV = "3.1.0.0-RC2"
+val scalatestV = "3.1.0-RC3"
+val scalatestplusScalacheckV = "3.1.0.0-RC3"
 
 // General Settings
 lazy val commonSettings = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,6 @@ lazy val scalatest = crossProject(JSPlatform, JVMPlatform)
     moduleName := "discipline-scalatest",
     libraryDependencies ++= Seq(
       "org.typelevel"     %%% "discipline-core"          % disciplineV,
-      "org.scalatest"     %%% "scalatest"                % scalatestV,
       "org.scalatestplus" %%% "scalatestplus-scalacheck" % scalatestplusScalacheckV,
     ),
   )
@@ -40,8 +39,7 @@ lazy val contributors = Seq(
 val betterMonadicForV = "0.3.1"
 val disciplineV = "1.0.0"
 val kindProjectorV = "0.10.3"
-val scalatestV = "3.1.0-RC3"
-val scalatestplusScalacheckV = "3.1.0.0-RC3"
+val scalatestplusScalacheckV = "3.1.0.0-RC2"
 
 // General Settings
 lazy val commonSettings = Seq(


### PR DESCRIPTION
It's premature to depend on Scalatest 3.2.0