### PR TITLE
Update scalacheck-1-14 to 3.1.0.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,8 +15,8 @@ lazy val scalatest = crossProject(JSPlatform, JVMPlatform)
   .settings(
     moduleName := "discipline-scalatest",
     libraryDependencies ++= Seq(
-      "org.typelevel"     %%% "discipline-core"          % disciplineV,
-      "org.scalatestplus" %%% "scalatestplus-scalacheck" % scalatestplusScalacheckV,
+      "org.typelevel"     %%% "discipline-core" % disciplineV,
+      "org.scalatestplus" %%% "scalacheck-1-14" % scalatestplusScalacheckV,
     ),
   )
   .jsSettings(scalaJSStage in Test := FastOptStage)
@@ -37,7 +37,7 @@ lazy val contributors = Seq(
 )
 
 val disciplineV = "1.0.2"
-val scalatestplusScalacheckV = "3.1.0.0-RC2"
+val scalatestplusScalacheckV = "3.1.0.1"
 
 // General Settings
 lazy val commonSettings = Seq(

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -43,17 +43,6 @@ class TruthSuite extends AnyFunSuite with Discipline {
 }
 ```
 
-As of 1.x, `Discipline` is no longer limited to `FunSuite`.  It works with any ScalaTest `TestRegistration`:
-
-```tut:book
-import org.scalatest.freespec.AnyFreeSpec
-import org.typelevel.discipline.scalatest.Discipline
-
-class TruthSpec extends AnyFreeSpec with Discipline {
-  checkAll("Truth", TruthLaws.truth)
-}
-```
-
 ## Compatibility
 
 discipline-scalatest-1.0.0-M1 works with:

--- a/scalatest/src/main/scala/org/typelevel/discipline/scalatest/Discipline.scala
+++ b/scalatest/src/main/scala/org/typelevel/discipline/scalatest/Discipline.scala
@@ -1,14 +1,14 @@
 package org.typelevel.discipline
 package scalatest
 
-import org.scalatest.TestRegistration
+import org.scalatest.funsuite.AnyFunSuiteLike
 import org.scalatestplus.scalacheck.Checkers
 
-trait Discipline extends Checkers { self: TestRegistration =>
+trait Discipline extends Checkers { self: AnyFunSuiteLike =>
 
   def checkAll(name: String, ruleSet: Laws#RuleSet): Unit = {
     for ((id, prop) <- ruleSet.all.properties)
-      registerTest(s"${name}.${id}") {
+      test(s"${name}.${id}") {
         check(prop)
       }
   }

--- a/scalatest/src/test/scala/scalatest/org/typelevel/discipline/scalatest/DisciplineTest.scala
+++ b/scalatest/src/test/scala/scalatest/org/typelevel/discipline/scalatest/DisciplineTest.scala
@@ -1,13 +1,9 @@
 package org.typelevel.discipline
 package scalatest
 
-import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.funsuite.AnyFunSuite
 
 class DummyFunSuite extends AnyFunSuite with Discipline {
   checkAll("Dummy", DummyLaws.dummy)
 }
 
-class DummyFreeSpec extends AnyFreeSpec with Discipline {
-  checkAll("Dummy", DummyLaws.dummy)
-}


### PR DESCRIPTION
The artifact name has been changed, so manual dependency update required

`TestRegistration` trait has been deprecated and according to deprecation message no replacement is planned. So I partly reverted the changes made in #1 by @rossabaker 