### PR TITLE
Support FlatSpec and FunSpec

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,8 @@ lazy val docs = project
 
 lazy val contributors = Seq(
   "larsrh" -> "Lars Hupel",
-  "rossabaker" -> "Ross A. Baker"
+  "rossabaker" -> "Ross A. Baker",
+  "travisbrown" -> "Travis Brown"
 )
 
 val disciplineV = "1.0.2"

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -32,13 +32,13 @@ object TruthLaws extends Laws {
 }
 ```
 
-discipline-scalatest provides a `Discipline` mixin, whose `checkAll` helper lets us easily check the laws in ScalaTest:
+discipline-scalatest provides a `FunSuiteDiscipline` mixin (as well as similar traits for `FlatSpec` and `FunSpec`), whose `checkAll` helper lets us easily check the laws in ScalaTest:
 
 ```scala mdoc
 import org.scalatest.funsuite.AnyFunSuite
-import org.typelevel.discipline.scalatest.Discipline
+import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 
-class TruthSuite extends AnyFunSuite with Discipline {
+class TruthSuite extends AnyFunSuite with FunSuiteDiscipline {
   checkAll("Truth", TruthLaws.truth)
 }
 ```

--- a/scalatest/src/main/scala/org/typelevel/discipline/scalatest/Discipline.scala
+++ b/scalatest/src/main/scala/org/typelevel/discipline/scalatest/Discipline.scala
@@ -1,15 +1,40 @@
 package org.typelevel.discipline
 package scalatest
 
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.funspec.AnyFunSpecLike
 import org.scalatest.funsuite.AnyFunSuiteLike
 import org.scalatestplus.scalacheck.Checkers
 
-trait Discipline extends Checkers { self: AnyFunSuiteLike =>
+trait Discipline {
+  def checkAll(name: String, ruleSet: Laws#RuleSet): Unit
+}
 
-  def checkAll(name: String, ruleSet: Laws#RuleSet): Unit =
+trait FlatSpecDiscipline extends Discipline { self: AnyFlatSpecLike =>
+  final def checkAll(name: String, ruleSet: Laws#RuleSet): Unit =
+    ruleSet.all.properties match {
+      case first +: rest =>
+        name should first._1 in Checkers.check(first._2)
+
+        for ((id, prop) <- rest)
+          it should id in Checkers.check(prop)
+    }
+}
+
+trait FunSpecDiscipline extends Discipline { self: AnyFunSpecLike =>
+  final def checkAll(name: String, ruleSet: Laws#RuleSet): Unit =
+    describe(name) {
+      for ((id, prop) <- ruleSet.all.properties)
+        it(id) {
+          Checkers.check(prop)
+        }
+    }
+}
+
+trait FunSuiteDiscipline extends Discipline { self: AnyFunSuiteLike =>
+  final def checkAll(name: String, ruleSet: Laws#RuleSet): Unit =
     for ((id, prop) <- ruleSet.all.properties)
       test(s"${name}.${id}") {
-        check(prop)
+        Checkers.check(prop)
       }
-
 }

--- a/scalatest/src/test/scala/scalatest/org/typelevel/discipline/scalatest/DisciplineTest.scala
+++ b/scalatest/src/test/scala/scalatest/org/typelevel/discipline/scalatest/DisciplineTest.scala
@@ -1,8 +1,14 @@
 package org.typelevel.discipline
 package scalatest
 
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.funsuite.AnyFunSuite
 
-class DummyFunSuite extends AnyFunSuite with Discipline {
+trait DummyBase extends Discipline {
   checkAll("Dummy", DummyLaws.dummy)
 }
+
+class DummyFlatSpec extends AnyFlatSpec with DummyBase with FlatSpecDiscipline
+class DummyFunSpec extends AnyFunSpec with DummyBase with FunSpecDiscipline
+class DummyFunSuite extends AnyFunSuite with DummyBase with FunSuiteDiscipline

--- a/scalatest/src/test/scala/scalatest/org/typelevel/discipline/scalatest/laws.scala
+++ b/scalatest/src/test/scala/scalatest/org/typelevel/discipline/scalatest/laws.scala
@@ -5,12 +5,14 @@ import org.typelevel.discipline.Laws
 
 object Dummy {
   def prop = Prop(_ => Prop.Result(status = Prop.True))
+  def prop2 = Prop(true)
 }
 
 object DummyLaws extends Laws {
   def dummy = new DefaultRuleSet(
     name = "dummy",
     parent = None,
-    "true" -> Dummy.prop
+    "true" -> Dummy.prop,
+    "alsoTrue" -> Dummy.prop2
   )
 }


### PR DESCRIPTION
This is a breaking change but I think it's something we should do before 1.0.0.

In #1 @rossabaker made it possible to use `Discipline` with any ScalaTest testing style, but `TestRegistration` was deprecated in the final 3.1.0 release (with explicitly no replacement), so @jhnsmth switched us back to `FunSuite` in #39 (which is in the most recent 1.0.0-RC2).

I've got a few cases where it would be useful for me to use `checkAll` with other test styles, so I've added support for `FunSpec` and `FlatSpec`, using the idioms for those styles. The new tests look like this:

```
[info] DummyFlatSpec:
[info] Dummy
[info] - should dummy.alsoTrue
[info] - should dummy.true
...
[info] DummyFunSpec:
[info] Dummy
[info] - dummy.alsoTrue
[info] - dummy.true
...
[info] DummyFunSuite:
[info] - Dummy.dummy.alsoTrue
[info] - Dummy.dummy.true
```

I've also changed the `Discipline` traits to use `Checkers.check` instead of extending `Checkers`, to minimize the extra stuff brought in for users.

We could support the other four (or however many) testing styles, but personally I don't really want to encourage people to use anything beyond these three. `FunSuite` is what we've always supported, `FunSpec` is my personal preference, and `FlatSpec` is the officially suggested one, and I think we can stop there. If anyone wants to add others in future 1.x releases it won't be a breaking change.

The migration from 1.0.0-RC2 is easy enough: just change `Discipline` to `FunSuiteDiscipline`.