### PR TITLE
Relay implicit configuration

### DIFF
--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -36,9 +36,10 @@ discipline-scalatest provides a `FunSuiteDiscipline` mixin (as well as similar t
 
 ```scala mdoc
 import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.scalacheck.Checkers
 import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 
-class TruthSuite extends AnyFunSuite with FunSuiteDiscipline {
+class TruthSuite extends AnyFunSuite with FunSuiteDiscipline with Checkers {
   checkAll("Truth", TruthLaws.truth)
 }
 ```

--- a/scalatest/src/main/scala/org/typelevel/discipline/scalatest/Discipline.scala
+++ b/scalatest/src/main/scala/org/typelevel/discipline/scalatest/Discipline.scala
@@ -1,17 +1,18 @@
 package org.typelevel.discipline
 package scalatest
 
+import org.scalactic.source.Position
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.funspec.AnyFunSpecLike
 import org.scalatest.funsuite.AnyFunSuiteLike
 import org.scalatestplus.scalacheck.Checkers
 
 trait Discipline {
-  def checkAll(name: String, ruleSet: Laws#RuleSet): Unit
+  def checkAll(name: String, ruleSet: Laws#RuleSet)(implicit pos: Position): Unit
 }
 
 trait FlatSpecDiscipline extends Discipline { self: AnyFlatSpecLike =>
-  final def checkAll(name: String, ruleSet: Laws#RuleSet): Unit =
+  final def checkAll(name: String, ruleSet: Laws#RuleSet)(implicit pos: Position): Unit =
     ruleSet.all.properties match {
       case first +: rest =>
         name should first._1 in Checkers.check(first._2)
@@ -22,7 +23,7 @@ trait FlatSpecDiscipline extends Discipline { self: AnyFlatSpecLike =>
 }
 
 trait FunSpecDiscipline extends Discipline { self: AnyFunSpecLike =>
-  final def checkAll(name: String, ruleSet: Laws#RuleSet): Unit =
+  final def checkAll(name: String, ruleSet: Laws#RuleSet)(implicit pos: Position): Unit =
     describe(name) {
       for ((id, prop) <- ruleSet.all.properties)
         it(id) {
@@ -32,7 +33,7 @@ trait FunSpecDiscipline extends Discipline { self: AnyFunSpecLike =>
 }
 
 trait FunSuiteDiscipline extends Discipline { self: AnyFunSuiteLike =>
-  final def checkAll(name: String, ruleSet: Laws#RuleSet): Unit =
+  final def checkAll(name: String, ruleSet: Laws#RuleSet)(implicit pos: Position): Unit =
     for ((id, prop) <- ruleSet.all.properties)
       test(s"${name}.${id}") {
         Checkers.check(prop)

--- a/scalatest/src/main/scala/org/typelevel/discipline/scalatest/Discipline.scala
+++ b/scalatest/src/main/scala/org/typelevel/discipline/scalatest/Discipline.scala
@@ -1,18 +1,24 @@
 package org.typelevel.discipline
 package scalatest
 
+import org.scalactic.Prettifier
 import org.scalactic.source.Position
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.funspec.AnyFunSpecLike
 import org.scalatest.funsuite.AnyFunSuiteLike
+import org.scalatest.prop.Configuration
 import org.scalatestplus.scalacheck.Checkers
 
-trait Discipline {
-  def checkAll(name: String, ruleSet: Laws#RuleSet)(implicit pos: Position): Unit
+trait Discipline { self: Configuration =>
+  def checkAll(name: String, ruleSet: Laws#RuleSet)(implicit config: PropertyCheckConfiguration,
+                                                    prettifier: Prettifier,
+                                                    pos: Position): Unit
 }
 
-trait FlatSpecDiscipline extends Discipline { self: AnyFlatSpecLike =>
-  final def checkAll(name: String, ruleSet: Laws#RuleSet)(implicit pos: Position): Unit =
+trait FlatSpecDiscipline extends Discipline { self: AnyFlatSpecLike with Configuration =>
+  final def checkAll(name: String, ruleSet: Laws#RuleSet)(implicit config: PropertyCheckConfiguration,
+                                                          prettifier: Prettifier,
+                                                          pos: Position): Unit =
     ruleSet.all.properties match {
       case first +: rest =>
         name should first._1 in Checkers.check(first._2)
@@ -22,8 +28,10 @@ trait FlatSpecDiscipline extends Discipline { self: AnyFlatSpecLike =>
     }
 }
 
-trait FunSpecDiscipline extends Discipline { self: AnyFunSpecLike =>
-  final def checkAll(name: String, ruleSet: Laws#RuleSet)(implicit pos: Position): Unit =
+trait FunSpecDiscipline extends Discipline { self: AnyFunSpecLike with Configuration =>
+  final def checkAll(name: String, ruleSet: Laws#RuleSet)(implicit config: PropertyCheckConfiguration,
+                                                          prettifier: Prettifier,
+                                                          pos: Position): Unit =
     describe(name) {
       for ((id, prop) <- ruleSet.all.properties)
         it(id) {
@@ -32,8 +40,10 @@ trait FunSpecDiscipline extends Discipline { self: AnyFunSpecLike =>
     }
 }
 
-trait FunSuiteDiscipline extends Discipline { self: AnyFunSuiteLike =>
-  final def checkAll(name: String, ruleSet: Laws#RuleSet)(implicit pos: Position): Unit =
+trait FunSuiteDiscipline extends Discipline { self: AnyFunSuiteLike with Configuration =>
+  final def checkAll(name: String, ruleSet: Laws#RuleSet)(implicit config: PropertyCheckConfiguration,
+                                                          prettifier: Prettifier,
+                                                          pos: Position): Unit =
     for ((id, prop) <- ruleSet.all.properties)
       test(s"${name}.${id}") {
         Checkers.check(prop)

--- a/scalatest/src/main/scala/org/typelevel/discipline/scalatest/Discipline.scala
+++ b/scalatest/src/main/scala/org/typelevel/discipline/scalatest/Discipline.scala
@@ -10,6 +10,26 @@ import org.scalatest.prop.Configuration
 import org.scalatestplus.scalacheck.Checkers
 
 trait Discipline { self: Configuration =>
+
+  /**
+   * Convert from our configuration type to the one required by `Checkers`.
+   *
+   * We don't extend `Checkers` because we want to leave the user as much
+   * control as possible over available testing styles. Unfortunately we need
+   * this conversion because ScalaTest defines `PropertyCheckConfiguration`
+   * as a case class in the `Configuration` trait.
+   */
+  final protected[this] def convertConfiguration(
+    config: PropertyCheckConfiguration
+  ): Checkers.PropertyCheckConfiguration =
+    Checkers.PropertyCheckConfiguration(
+      config.minSuccessful,
+      config.maxDiscardedFactor,
+      config.minSize,
+      config.sizeRange,
+      config.workers
+    )
+
   def checkAll(name: String, ruleSet: Laws#RuleSet)(implicit config: PropertyCheckConfiguration,
                                                     prettifier: Prettifier,
                                                     pos: Position): Unit
@@ -21,10 +41,10 @@ trait FlatSpecDiscipline extends Discipline { self: AnyFlatSpecLike with Configu
                                                           pos: Position): Unit =
     ruleSet.all.properties match {
       case first +: rest =>
-        name should first._1 in Checkers.check(first._2)
+        name should first._1 in Checkers.check(first._2)(convertConfiguration(config), prettifier, pos)
 
         for ((id, prop) <- rest)
-          it should id in Checkers.check(prop)
+          it should id in Checkers.check(prop)(convertConfiguration(config), prettifier, pos)
     }
 }
 
@@ -35,7 +55,7 @@ trait FunSpecDiscipline extends Discipline { self: AnyFunSpecLike with Configura
     describe(name) {
       for ((id, prop) <- ruleSet.all.properties)
         it(id) {
-          Checkers.check(prop)
+          Checkers.check(prop)(convertConfiguration(config), prettifier, pos)
         }
     }
 }
@@ -46,6 +66,6 @@ trait FunSuiteDiscipline extends Discipline { self: AnyFunSuiteLike with Configu
                                                           pos: Position): Unit =
     for ((id, prop) <- ruleSet.all.properties)
       test(s"${name}.${id}") {
-        Checkers.check(prop)
+        Checkers.check(prop)(convertConfiguration(config), prettifier, pos)
       }
 }

--- a/scalatest/src/test/scala/scalatest/org/typelevel/discipline/scalatest/DisciplineTest.scala
+++ b/scalatest/src/test/scala/scalatest/org/typelevel/discipline/scalatest/DisciplineTest.scala
@@ -4,8 +4,9 @@ package scalatest
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.scalacheck.Checkers
 
-trait DummyBase extends Discipline {
+trait DummyBase extends Discipline with Checkers {
   checkAll("Dummy", DummyLaws.dummy)
 }
 


### PR DESCRIPTION
Trying [1.0.0-RC3 out in Cats](https://github.com/typelevel/cats/pull/3256) highlighted the fact that my switch from extending `Checkers` and using `check` to `Checkers.check` meant we were losing implicit configuration. I've fixed this here not by switching back to `with Checkers`, but instead by requiring and passing along all the implicit arguments needed by the [`check`](https://github.com/scalatest/scalatestplus-scalacheck/blob/3dcd99c0efd9612101757c5116819a2ac59796ca/scalatestPlusScalaCheck/src/main/scala/org/scalatestplus/scalacheck/Checkers.scala#L369) call we're making.

I've confirmed that this change fixes the issues we were seeing in the Cats tests.

## Why not just extend Checkers?

Having the Discipline traits extend `Checkers` (as we did in previous releases) means that users who already have `ScalaCheckDrivenPropertyChecks` or `ScalaCheckPropertyChecks` are also forced to bring in `Checkers`. In my view the worst thing about ScalaTest is that it's just so enormous, and that it's far too easy to lose control of consistency in testing styles. I might choose to use the `PropertyChecks` traits specifically because I want tests to be written with `forAll`, not `check`. If the Discipline traits extend `Checkers`, then I can't use them without making all the `check` methods available as well.

The downside of not extending `Checkers` is that because ScalaTest defines `PropertyCheckConfiguration` as a case class in the `Configuration` trait (even though it doesn't refer to any other definitions in the trait), we have to do a kind of weird conversion from _our_ `PropertyCheckConfiguration` to `Checkers.PropertyCheckConfiguration`. This is entirely hidden from users, though, and I think it's worth it.

## Other benefits

The change in this PR has the additional advantage over all previous discipline-scalatest releases of giving us useful location information in test failure messages. For example, this is the report from a failing test in all current releases:

```scala
[info] DummyFunSuite:
[info] - Dummy.dummy.alsoTrue *** FAILED ***
[info]   GeneratorDrivenPropertyCheckFailedException was thrown during property evaluation.
[info]    (Discipline.scala:38)
[info]     Falsified after 0 successful property evaluations.
[info]     Location: (Discipline.scala:38)
[info]     Occurred when passed generated values (
[info]   
[info]     )
```
The location here points to the `check` call in discipline-scalatest, which is where the implicit position is resolved. This is absolutely useless, and I'm surprised I hadn't noticed it before.

With this PR we get the actual test location:

```scala
[info] DummyFunSuite:
[info] - Dummy.dummy.alsoTrue *** FAILED ***
[info]   GeneratorDrivenPropertyCheckFailedException was thrown during property evaluation.
[info]    (DisciplineTest.scala:10)
[info]     Falsified after 0 successful property evaluations.
[info]     Location: (DisciplineTest.scala:10)
[info]     Occurred when passed generated values (
[info]   
[info]     )
```

This change also means that if the user has defined a custom prettifier, it will be used when reporting law-checking failures (all previous releases have just used the default prettifier).
