### PR TITLE
Update Scala.js and scalatestplus-scalacheck-1-14

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ lazy val contributors = Seq(
 )
 
 val disciplineV = "1.0.2"
-val scalatestplusScalacheckV = "3.1.0.1"
+val scalatestplusScalacheckV = "3.1.1.1"
 
 // General Settings
 lazy val commonSettings = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.0.0-RC2")
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.0.0")
 
 addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.2.0")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")


### PR DESCRIPTION
Once this is merged I'll publish 1.0.1 with Scala.js 1.0.1 support. (I guess we could publish 1.0.0 artefacts for Scala.js 1 depending on ScalaTest 3.1.0 instead of 3.1.1 now, but I don't personally think it's worth the effort.) 