### PR TITLE
Add support for FreeSpec

### DIFF
--- a/scalatest/src/main/scala/org/typelevel/discipline/scalatest/Discipline.scala
+++ b/scalatest/src/main/scala/org/typelevel/discipline/scalatest/Discipline.scala
@@ -25,6 +25,7 @@ package scalatest
 import org.scalactic.Prettifier
 import org.scalactic.source.Position
 import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.freespec.AnyFreeSpecLike
 import org.scalatest.funspec.AnyFunSpecLike
 import org.scalatest.funsuite.AnyFunSuiteLike
 import org.scalatest.prop.Configuration
@@ -71,6 +72,18 @@ trait FlatSpecDiscipline extends Discipline { self: AnyFlatSpecLike with Configu
           it should id in Checkers.check(prop)(convertConfiguration(config), prettifier, pos)
 
       case Nil =>
+    }
+}
+
+trait FreeSpecDiscipline extends Discipline { self: AnyFreeSpecLike with Configuration =>
+  final def checkAll(name: String,
+                     ruleSet: Laws#RuleSet
+  )(implicit config: PropertyCheckConfiguration, prettifier: Prettifier, pos: Position): Unit =
+    name - {
+      for ((id, prop) <- ruleSet.all.properties)
+        id in {
+          Checkers.check(prop)(convertConfiguration(config), prettifier, pos)
+        }
     }
 }
 

--- a/scalatest/src/test/scala/scalatest/org/typelevel/discipline/scalatest/DisciplineTest.scala
+++ b/scalatest/src/test/scala/scalatest/org/typelevel/discipline/scalatest/DisciplineTest.scala
@@ -23,6 +23,7 @@ package org.typelevel.discipline
 package scalatest
 
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.wordspec.AnyWordSpec
@@ -33,6 +34,7 @@ trait DummyBase extends Discipline with Checkers {
 }
 
 class DummyFlatSpec extends AnyFlatSpec with DummyBase with FlatSpecDiscipline
+class DummyFreeSpec extends AnyFreeSpec with DummyBase with FreeSpecDiscipline
 class DummyFunSpec extends AnyFunSpec with DummyBase with FunSpecDiscipline
 class DummyFunSuite extends AnyFunSuite with DummyBase with FunSuiteDiscipline
 class DummyWordSpec extends AnyWordSpec with DummyBase with WordSpecDiscipline


### PR DESCRIPTION
Add a `FreeSpecDiscipline` that can be used with [AnyFreeSpec](https://www.scalatest.org/scaladoc/3.2.19/org/scalatest/freespec/AnyFreeSpec.html).
